### PR TITLE
macOS: AX selection manipulation

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -387,6 +387,16 @@ typedef struct {
   uintptr_t text_len;
 } ghostty_text_s;
 
+typedef struct {
+  uint32_t location;
+  uint32_t length;
+} ghostty_selection_range_s;
+
+typedef struct {
+  uint32_t row;
+  uint32_t col;
+} ghostty_cursor_position_s;
+
 typedef enum {
   GHOSTTY_POINT_ACTIVE,
   GHOSTTY_POINT_VIEWPORT,
@@ -1108,11 +1118,18 @@ void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                 void*,
                                                 bool);
 bool ghostty_surface_has_selection(ghostty_surface_t);
+bool ghostty_surface_selection_range(ghostty_surface_t,
+                                      ghostty_selection_range_s*);
+bool ghostty_surface_set_selection_range(ghostty_surface_t,
+                                         uint32_t,
+                                         uint32_t);
 bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 bool ghostty_surface_read_text(ghostty_surface_t,
                                ghostty_selection_s,
                                ghostty_text_s*);
 void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
+bool ghostty_surface_cursor_position(ghostty_surface_t,
+                                      ghostty_cursor_position_s*);
 
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -2147,6 +2147,10 @@ extension Ghostty.SurfaceView {
 // MARK: Accessibility
 
 extension Ghostty.SurfaceView {
+    private static let accessibilityCursorPositionAttribute = NSAccessibility.Attribute(
+        rawValue: "AXGhosttyCursorPosition"
+    )
+
     /// Indicates that this view should be exposed to accessibility tools like VoiceOver.
     /// By returning true, we make the terminal surface accessible to screen readers
     /// and other assistive technologies.
@@ -2174,7 +2178,17 @@ extension Ghostty.SurfaceView {
     /// This allows VoiceOver and other assistive technologies to understand
     /// what text the user has selected.
     override func accessibilitySelectedTextRange() -> NSRange {
-        return selectedRange()
+        guard let surface = self.surface else { return NSRange() }
+
+        var selectionRange = ghostty_selection_range_s()
+        guard ghostty_surface_selection_range(surface, &selectionRange) else { return NSRange() }
+
+        let content = cachedScreenContents.get()
+        return nsRangeFromUTF8Offsets(
+            location: Int(selectionRange.location),
+            length: Int(selectionRange.length),
+            in: content
+        )
     }
 
     /// Returns the currently selected text as a string.
@@ -2195,21 +2209,23 @@ extension Ghostty.SurfaceView {
     /// This helps assistive technologies understand the size of the content.
     override func accessibilityNumberOfCharacters() -> Int {
         let content = cachedScreenContents.get()
-        return content.count
+        return content.utf16.count
     }
 
     /// Returns the visible character range for the terminal.
     /// For terminals, we typically show all content as visible.
     override func accessibilityVisibleCharacterRange() -> NSRange {
         let content = cachedScreenContents.get()
-        return NSRange(location: 0, length: content.count)
+        return NSRange(location: 0, length: content.utf16.count)
     }
 
     /// Returns the line number for a given character index.
     /// This helps assistive technologies navigate by line.
     override func accessibilityLine(for index: Int) -> Int {
         let content = cachedScreenContents.get()
-        let substring = String(content.prefix(index))
+        let clampedIndex = max(0, min(index, content.utf16.count))
+        let endIndex = String.Index(utf16Offset: clampedIndex, in: content)
+        let substring = String(content[..<endIndex])
         return substring.components(separatedBy: .newlines).count - 1
     }
 
@@ -2242,6 +2258,125 @@ extension Ghostty.SurfaceView {
         }
 
         return NSAttributedString(string: plainString, attributes: attributes)
+    }
+
+    override func setAccessibilitySelectedTextRange(_ range: NSRange) {
+        guard let surface = self.surface else { return }
+        let content = cachedScreenContents.get()
+
+        guard let offsets = utf8Offsets(from: range, in: content) else { return }
+        _ = ghostty_surface_set_selection_range(
+            surface,
+            UInt32(offsets.location),
+            UInt32(offsets.length)
+        )
+    }
+
+    override func setAccessibilitySelectedText(_ selectedText: String?) {
+        let text = selectedText ?? ""
+
+        if text.isEmpty {
+            if let surface = self.surface {
+                _ = ghostty_surface_set_selection_range(surface, 0, 0)
+            }
+            return
+        }
+
+        surfaceModel?.sendText(text)
+
+        if let surface = self.surface {
+            _ = ghostty_surface_set_selection_range(surface, 0, 0)
+        }
+    }
+
+    override func accessibilityAttributeNames() -> [NSAccessibility.Attribute] {
+        var attrs = super.accessibilityAttributeNames()
+        attrs.append(Self.accessibilityCursorPositionAttribute)
+        return attrs
+    }
+
+    override func accessibilitySetValue(_ value: Any?, forAttribute attribute: NSAccessibility.Attribute) {
+        switch attribute {
+        case .selectedTextRange:
+            if let nsValue = value as? NSValue {
+                setAccessibilitySelectedTextRange(nsValue.rangeValue)
+            } else if let value {
+                let cfValue: CFTypeRef = value as CFTypeRef
+                if CFGetTypeID(cfValue) == AXValueGetTypeID() {
+                    let axValue = unsafeBitCast(cfValue, to: AXValue.self)
+                    var cfRange = CFRange()
+                    if AXValueGetValue(axValue, .cfRange, &cfRange) {
+                        let range = NSRange(location: cfRange.location, length: cfRange.length)
+                        setAccessibilitySelectedTextRange(range)
+                    }
+                }
+            }
+
+        case .selectedText:
+            setAccessibilitySelectedText(value as? String)
+
+        default:
+            super.accessibilitySetValue(value, forAttribute: attribute)
+        }
+    }
+
+    override func accessibilityAttributeValue(_ attribute: NSAccessibility.Attribute) -> Any? {
+        if attribute == Self.accessibilityCursorPositionAttribute {
+            guard let surface = self.surface else { return nil }
+            var pos = ghostty_cursor_position_s()
+            guard ghostty_surface_cursor_position(surface, &pos) else { return nil }
+            return [
+                "row": NSNumber(value: pos.row),
+                "col": NSNumber(value: pos.col),
+            ]
+        }
+
+        return super.accessibilityAttributeValue(attribute)
+    }
+
+    override func accessibilityIsAttributeSettable(_ attribute: NSAccessibility.Attribute) -> Bool {
+        if attribute == .selectedTextRange || attribute == .selectedText { return true }
+        if attribute == Self.accessibilityCursorPositionAttribute { return false }
+        return super.accessibilityIsAttributeSettable(attribute)
+    }
+
+    private func nsRangeFromUTF8Offsets(
+        location: Int,
+        length: Int,
+        in content: String
+    ) -> NSRange {
+        guard location >= 0, length >= 0 else { return NSRange() }
+        guard let startUtf8 = content.utf8.index(
+            content.utf8.startIndex,
+            offsetBy: location,
+            limitedBy: content.utf8.endIndex
+        ) else { return NSRange() }
+        guard let endUtf8 = content.utf8.index(
+            startUtf8,
+            offsetBy: length,
+            limitedBy: content.utf8.endIndex
+        ) else { return NSRange() }
+        guard let startIndex = startUtf8.samePosition(in: content),
+              let endIndex = endUtf8.samePosition(in: content) else {
+            return NSRange()
+        }
+
+        return NSRange(startIndex..<endIndex, in: content)
+    }
+
+    private func utf8Offsets(
+        from range: NSRange,
+        in content: String
+    ) -> (location: Int, length: Int)? {
+        guard let stringRange = Range(range, in: content) else { return nil }
+        guard let startUtf8 = stringRange.lowerBound.samePosition(in: content.utf8),
+              let endUtf8 = stringRange.upperBound.samePosition(in: content.utf8) else {
+            return nil
+        }
+
+        let location = content.utf8.distance(from: content.utf8.startIndex, to: startUtf8)
+        let end = content.utf8.distance(from: content.utf8.startIndex, to: endUtf8)
+        return (location, end - location)
     }
 
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1875,6 +1875,13 @@ pub const Text = struct {
     }
 };
 
+/// A selection range expressed as UTF-8 byte offsets into the flattened
+/// screen text (see `selectionString`).
+pub const SelectionRange = struct {
+    start: usize,
+    len: usize,
+};
+
 /// Grab the value of text at the given selection point. Note that the
 /// selection structure is used as a way to determine the area of the
 /// screen to read from, it doesn't have to match the user's current
@@ -2026,6 +2033,99 @@ pub fn selectionString(self: *Surface, alloc: Allocator) !?[:0]const u8 {
         .sel = sel,
         .trim = false,
     });
+}
+
+/// Returns the current selection range as UTF-8 byte offsets into the
+/// flattened screen text (see `selectionString`).
+pub fn selectionRange(self: *Surface) !?SelectionRange {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const sel = screen.selection orelse return null;
+
+    const full_sel = terminal.Selection.init(
+        screen.pages.getTopLeft(.screen),
+        screen.pages.getBottomRight(.screen) orelse return null,
+        false,
+    );
+
+    var map: terminal.StringMap = undefined;
+    const text = try screen.selectionString(self.alloc, .{
+        .sel = full_sel,
+        .trim = false,
+        .map = &map,
+    });
+    defer self.alloc.free(text);
+    defer map.deinit(self.alloc);
+
+    const start_pin = sel.topLeft(screen);
+    const end_pin = sel.bottomRight(screen);
+
+    var start_idx: ?usize = null;
+    var end_idx: ?usize = null;
+    for (map.map, 0..) |pin, idx| {
+        if (start_idx == null and pin.node == start_pin.node and pin.x == start_pin.x and pin.y == start_pin.y) {
+            start_idx = idx;
+        }
+        if (pin.node == end_pin.node and pin.x == end_pin.x and pin.y == end_pin.y) {
+            end_idx = idx;
+        }
+    }
+
+    if (start_idx == null or end_idx == null) return null;
+    if (end_idx.? < start_idx.?) return null;
+
+    return .{
+        .start = start_idx.?,
+        .len = end_idx.? - start_idx.? + 1,
+    };
+}
+
+/// Set the selection range using UTF-8 byte offsets into the flattened
+/// screen text (see `selectionString`). Returns false if the range is
+/// out of bounds.
+pub fn setSelectionRange(self: *Surface, start: usize, len: usize) !bool {
+    self.renderer_state.mutex.lock();
+    var did_set = false;
+    defer if (did_set) self.queueRender() catch |err| {
+        log.warn("failed to queue render after selection range update err={}", .{err});
+    };
+    defer self.renderer_state.mutex.unlock();
+
+    if (len == 0) {
+        try self.setSelection(null);
+        did_set = true;
+        return true;
+    }
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const full_sel = terminal.Selection.init(
+        screen.pages.getTopLeft(.screen),
+        screen.pages.getBottomRight(.screen) orelse return false,
+        false,
+    );
+
+    var map: terminal.StringMap = undefined;
+    const text = try screen.selectionString(self.alloc, .{
+        .sel = full_sel,
+        .trim = false,
+        .map = &map,
+    });
+    defer self.alloc.free(text);
+    defer map.deinit(self.alloc);
+
+    if (map.map.len == 0) return false;
+    if (start >= map.map.len) return false;
+
+    const end_unclamped = start + len - 1;
+    const end = if (end_unclamped < map.map.len) end_unclamped else map.map.len - 1;
+    const start_pin = map.map[start];
+    const end_pin = map.map[end];
+
+    try self.setSelection(terminal.Selection.init(start_pin, end_pin, false));
+    did_set = true;
+    return true;
 }
 
 /// Returns the pwd of the terminal, if any. This is always copied because

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1279,6 +1279,18 @@ pub const CAPI = struct {
         }
     };
 
+    // ghostty_selection_range_s
+    const SelectionRange = extern struct {
+        location: u32,
+        length: u32,
+    };
+
+    // ghostty_cursor_position_s
+    const CursorPosition = extern struct {
+        row: u32,
+        col: u32,
+    };
+
     // ghostty_point_s
     const Point = extern struct {
         tag: Tag,
@@ -1579,6 +1591,40 @@ pub const CAPI = struct {
         return surface.core_surface.hasSelection();
     }
 
+    /// Returns the selection range as UTF-8 byte offsets into the flattened
+    /// screen text. Returns false if there is no selection.
+    export fn ghostty_surface_selection_range(
+        surface: *Surface,
+        result: *SelectionRange,
+    ) bool {
+        const range = surface.core_surface.selectionRange() catch |err| {
+            log.warn("error reading selection range err={}", .{err});
+            return false;
+        } orelse return false;
+
+        result.* = .{
+            .location = @intCast(range.start),
+            .length = @intCast(range.len),
+        };
+        return true;
+    }
+
+    /// Sets the selection range using UTF-8 byte offsets into the flattened
+    /// screen text. Returns false if the range is out of bounds.
+    export fn ghostty_surface_set_selection_range(
+        surface: *Surface,
+        location: u32,
+        length: u32,
+    ) bool {
+        return surface.core_surface.setSelectionRange(
+            @intCast(location),
+            @intCast(length),
+        ) catch |err| {
+            log.warn("error setting selection range err={}", .{err});
+            return false;
+        };
+    }
+
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(
@@ -1594,6 +1640,23 @@ pub const CAPI = struct {
 
         // Read the text from the selection.
         return readTextLocked(surface, core_sel, result);
+    }
+
+    /// Returns the current cursor position in screen coordinates (row, col).
+    export fn ghostty_surface_cursor_position(
+        surface: *Surface,
+        result: *CursorPosition,
+    ) bool {
+        const core_surface = &surface.core_surface;
+        core_surface.renderer_state.mutex.lock();
+        defer core_surface.renderer_state.mutex.unlock();
+
+        const cursor = core_surface.renderer_state.terminal.screens.active.cursor;
+        result.* = .{
+            .row = @intCast(cursor.y),
+            .col = @intCast(cursor.x),
+        };
+        return true;
     }
 
     /// Read some arbitrary text from the surface.


### PR DESCRIPTION
Adds AX selection setters and cursor position so assistive tools can set/replace selections without key simulation.